### PR TITLE
Add reddit galleries

### DIFF
--- a/src/clients/reddit.cr
+++ b/src/clients/reddit.cr
@@ -118,6 +118,7 @@ module SubredditResponse
     property created : Float32
     property is_video : Bool
     property media : Media | Nil
+    property media_metadata : Hash(String, MediaMetadata) | Nil
     property name : String
     property permalink : String
     property title : String
@@ -137,5 +138,13 @@ module SubredditResponse
 
   class OEmbed < Base
     property html : String
+  end
+
+  class MediaMetadata < Base
+    property s : Source
+  end
+
+  class Source < Base
+    property u : String
   end
 end

--- a/src/formatters/reddit.cr
+++ b/src/formatters/reddit.cr
@@ -1,5 +1,12 @@
 class Formatters::Reddit
-  getter response : SubredditResponse::Root
+  alias Response = SubredditResponse::Root
+  alias Child = SubredditResponse::Child
+  alias Media = SubredditResponse::Media
+  alias OEmbed = SubredditResponse::OEmbed
+  alias RedditVideo = SubredditResponse::RedditVideo
+  alias MediaMetadata = Hash(String, SubredditResponse::MediaMetadata)
+
+  getter response : Response
   getter config : SubredditConfig
 
   def initialize(@response, @config)
@@ -38,8 +45,8 @@ class Formatters::Reddit
     end
   end
 
-  private def content_html(item : SubredditResponse::Child) : String
-    if media = item.data.media
+  private def content_html(item : Child) : String
+    if media = video_or_embed(item)
       if (video_data = media.reddit_video)
         video_content(video_data)
       elsif oembed_data = media.oembed
@@ -47,30 +54,36 @@ class Formatters::Reddit
       else
         fallback_content(item)
       end
+    elsif gallery_items = gallery_root(item)
+      gallery_content(gallery_items)
     else
       image_content(item)
     end
   end
 
-  private def fallback_content(item : SubredditResponse::Child) : String
+  private def fallback_content(item : Child) : String
     <<-HTML.strip
       <p>⚠️ Something went wrong. Here's the item:</p>
       <pre style="white-space: pre-wrap;">#{item.to_json}</pre>
     HTML
   end
 
-  private def image_content(item : SubredditResponse::Child) : String
+  private def video_or_embed(item : Child) : Media | Nil
+    item.data.media
+  end
+
+  private def image_content(item : Child) : String
     <<-HTML.strip
       <img src="#{item.data.url}" />
     HTML
   end
 
-  private def oembed_content(oembed_data : SubredditResponse::OEmbed) : String
+  private def oembed_content(oembed_data : OEmbed) : String
     HTML.unescape(oembed_data.html)
   end
 
   private def video_content(
-    media_data : SubredditResponse::RedditVideo
+    media_data : RedditVideo
   ) : String
     <<-HTML.strip
       <video autoplay loop
@@ -81,5 +94,17 @@ class Formatters::Reddit
         Your browser does not support the video tag.
       </video>
     HTML
+  end
+
+  private def gallery_root(item : Child) : MediaMetadata | Nil
+    item.data.media_metadata
+  end
+
+  private def gallery_content(gallery_items : MediaMetadata) : String
+    gallery_items
+      .values
+      .map { |gallery_item| HTML.unescape(gallery_item.s.u) }
+      .map { |url| %{<img src="#{url}" />} }
+      .join
   end
 end


### PR DESCRIPTION
Image galleries exist on the item (post) via the media_metadata
dictionary. Each item is a key that points to a list of previews and
image info. Info like width, height, preview images (with width,
height, and urls) image type, url, etc.

The data is pretty terse. Each media_metadata has a few single-letter
keys that point to different values. To get the full URL, the path is:

```
abc123.s.u
```

I am calling s = source and u = url.