### PR TITLE
Add initial support for twitter video

### DIFF
--- a/src/clients/twitter.cr
+++ b/src/clients/twitter.cr
@@ -77,6 +77,16 @@ module TwitterResponse
 
   class Medium < Base
     getter media_url_https : String
+    getter type : String
+    getter video_info : VideoInfo | Nil
+  end
+
+  class VideoInfo < Base
+    getter variants : Array(Variant)
+  end
+
+  class Variant < Base
+    getter url : String
   end
 
   class User < Base


### PR DESCRIPTION
This adds the extended_entities.media[].video_info data to the parsed
response from twitter which contains URLs for videos. I thought I would
have to fetch each tweet individually, but I just didn't have good
examples of list responses with video/animated gif content.