### PR TITLE
Parse reddit better

### DIFF
--- a/src/clients/reddit.cr
+++ b/src/clients/reddit.cr
@@ -145,6 +145,7 @@ module SubredditResponse
   end
 
   class Source < Base
-    property u : String
+    property u : String | Nil
+    property gif : String | Nil
   end
 end

--- a/src/formatters/reddit.cr
+++ b/src/formatters/reddit.cr
@@ -5,6 +5,7 @@ class Formatters::Reddit
   alias OEmbed = SubredditResponse::OEmbed
   alias RedditVideo = SubredditResponse::RedditVideo
   alias MediaMetadata = Hash(String, SubredditResponse::MediaMetadata)
+  alias MediaSource = SubredditResponse::Source
 
   getter response : Response
   getter config : SubredditConfig
@@ -103,8 +104,13 @@ class Formatters::Reddit
   private def gallery_content(gallery_items : MediaMetadata) : String
     gallery_items
       .values
-      .map { |gallery_item| HTML.unescape(gallery_item.s.u) }
+      .map { |gallery_item| gallery_url(source: gallery_item.s) }
       .map { |url| %{<img src="#{url}" />} }
       .join
+  end
+
+  private def gallery_url(source : MediaSource)
+    fallback = "http://s.edwardloveall.com/error-check-your-json.png"
+    HTML.unescape(source.u || source.gif || fallback)
   end
 end


### PR DESCRIPTION
Sometimes a MediaMetadata's source would not have a `u` property. Instead it has a `gif` and `mp4` property. I think this happens when it's really small. I've now added the potential to use `gif` instead of `u`.